### PR TITLE
Fixed the /r/elm link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There is already a great foundation for WebGL with [elm-community/webgl](http://
 
 From there folks are working on projects for [terrain generation](https://twitter.com/czaplic/status/819324109674815489) and [loading 3D meshes](https://twitter.com/czaplic/status/820055313386586112).
 
-I think we can make it really fun and easy to create 3D graphics with Elm, and it is a very deep topic. I recommend exploring topics like [picking](http://away3d.com/tutorials/Introduction_to_Mouse_Picking),  [entity-component systems](https://en.wikipedia.org/wiki/Entity%E2%80%93component%E2%80%93system), [crazy shaders](https://www.shadertoy.com/), etc. by digging into a project of your own and (1) seeing what you need and (2) sharing your observations in blog posts on [/r/elm](reddit.com/r/elm).
+I think we can make it really fun and easy to create 3D graphics with Elm, and it is a very deep topic. I recommend exploring topics like [picking](http://away3d.com/tutorials/Introduction_to_Mouse_Picking),  [entity-component systems](https://en.wikipedia.org/wiki/Entity%E2%80%93component%E2%80%93system), [crazy shaders](https://www.shadertoy.com/), etc. by digging into a project of your own and (1) seeing what you need and (2) sharing your observations in blog posts on [/r/elm](https://reddit.com/r/elm).
 
 
 <br>


### PR DESCRIPTION
Current link goes to https://github.com/elm-lang/projects/blob/master/reddit.com/r/elm, instead of https://www.reddit.com/r/elm/. Just wanted to fix that.